### PR TITLE
Add support for yaml for spell creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,24 @@ Discord bot for interacting with the spellapi api
 |-|-|
 |?help|displays the help information for all commands|
 |?spell `<spell name>`|Finds the spell specified if possible. when there are multiple spells matching you can narrow it down using filters like "system=dnd" or "level: 2"|
-|?spell add| Requires an attachment to have been added to the message. Will upload the attachment to the backend and make it searchable. See below for the format of the attachment.|
+|?spell add| Will add a new spell, either using the content of the message or via attachment. See below for the format of the message or attachment.|
 
 ## Spell Attachment format
 
-Spells added via the bot need to be done using a file attachment. This file needs to be in a JSON format and look like below:
+Spells added via the bot can be done either using the body of the message or using a file attachment.
+
+Message content should be in the following format:
+
+```
+name: Example Spell 6
+description: Target creature you can see falls prone and cannot act until after your next turn.
+spelldata:
+    level: 2
+metadata:
+    system: test1
+```
+
+File attachments can either be in the format above or using the JSON format below:
 
 ```
 {

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.16
 require (
 	github.com/bwmarrin/discordgo v0.23.2
 	github.com/honeycombio/beeline-go v1.0.0
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -425,5 +425,7 @@ gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
To allow more user friendly creation of spells via the bot
yaml is supported via either file attachment or message content.
As a bonus effect of this approach it is possible to submit json
format via message content but that isn't likely to be used often.